### PR TITLE
Feature/answer save

### DIFF
--- a/src/main/java/com/moment/the/advice/ExceptionAdvice.java
+++ b/src/main/java/com/moment/the/advice/ExceptionAdvice.java
@@ -101,6 +101,6 @@ public class ExceptionAdvice {
     @ExceptionHandler(AnswerAlreadyExistsException.class)
     @ResponseStatus(HttpStatus.CONFLICT)
     protected CommonResult answerAlreadyExistsException(HttpServletRequest req, AnswerAlreadyExistsException e){
-        return responseService.getFailResult(Integer.valueOf(getMessage("answer-already-exists.code")), getMessage("answer-already-exists.code.msg"));
+        return responseService.getFailResult(Integer.valueOf(getMessage("answer-already-exists.code")), getMessage("answer-already-exists.msg"));
     }
 }

--- a/src/main/java/com/moment/the/advice/ExceptionAdvice.java
+++ b/src/main/java/com/moment/the/advice/ExceptionAdvice.java
@@ -39,7 +39,7 @@ public class ExceptionAdvice {
     // 사용자를 찾을 수 없습니다.
     @ExceptionHandler(UserNotFoundException.class)
     @ResponseStatus(HttpStatus.NOT_FOUND)
-    protected CommonResult userNotFoundException(HttpServletRequest request, UserNotFoundException e){
+    public CommonResult userNotFoundException(HttpServletRequest request, UserNotFoundException e){
         return responseService.getFailResult(Integer.valueOf(getMessage("userNotFound.code")), getMessage("userNotFound.msg"));
     }
     // 유저가 이미 존재합니다.

--- a/src/main/java/com/moment/the/advice/ExceptionAdvice.java
+++ b/src/main/java/com/moment/the/advice/ExceptionAdvice.java
@@ -97,4 +97,10 @@ public class ExceptionAdvice {
     public CommonResult invalidToken(HttpServletRequest req, InvalidTokenException e){
         return responseService.getFailResult(Integer.valueOf(getMessage("invalid-token.code")), getMessage("invalid-token.msg"));
     }
+
+    @ExceptionHandler(AnswerAlreadyExistsException.class)
+    @ResponseStatus(HttpStatus.CONFLICT)
+    protected CommonResult answerAlreadyExistsException(HttpServletRequest req, AnswerAlreadyExistsException e){
+        return responseService.getFailResult(Integer.valueOf(getMessage("answer-already-exists.code")), getMessage("answer-already-exists.code.msg"));
+    }
 }

--- a/src/main/java/com/moment/the/advice/exception/AnswerAlreadyExistsException.java
+++ b/src/main/java/com/moment/the/advice/exception/AnswerAlreadyExistsException.java
@@ -1,0 +1,13 @@
+package com.moment.the.advice.exception;
+
+public class AnswerAlreadyExistsException extends RuntimeException{
+    public AnswerAlreadyExistsException(String msg, Throwable t){
+        super(msg, t);
+    }
+    public AnswerAlreadyExistsException(String msg){
+        super(msg);
+    }
+    public AnswerAlreadyExistsException(){
+        super();
+    }
+}

--- a/src/main/java/com/moment/the/advice/handler/AnswerAlreadyExistsHandler.java
+++ b/src/main/java/com/moment/the/advice/handler/AnswerAlreadyExistsHandler.java
@@ -1,0 +1,13 @@
+package com.moment.the.advice.handler;
+
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+public class AnswerAlreadyExistsHandler {
+    public void handle(HttpServletRequest req, HttpServletResponse res) throws IOException, ServletException {
+        res.sendRedirect("/exception/answer-already-exists");
+    }
+}

--- a/src/main/java/com/moment/the/config/security/ExceptionHandlerFilter.java
+++ b/src/main/java/com/moment/the/config/security/ExceptionHandlerFilter.java
@@ -3,6 +3,7 @@ package com.moment.the.config.security;
 import com.moment.the.advice.ExceptionAdvice;
 import com.moment.the.advice.exception.AccessTokenExpiredException;
 import com.moment.the.advice.exception.InvalidTokenException;
+import com.moment.the.advice.exception.UserNotFoundException;
 import com.moment.the.domain.response.CommonResult;
 import com.moment.the.domain.response.ResponseService;
 import lombok.RequiredArgsConstructor;
@@ -31,9 +32,13 @@ public class ExceptionHandlerFilter extends OncePerRequestFilter {
             setExceptionRes(HttpStatus.BAD_REQUEST, res, exceptionAdvice.invalidToken(req, e));
         }catch(AccessTokenExpiredException e){
             setExceptionRes(HttpStatus.BAD_REQUEST, res, exceptionAdvice.accessTokenExpiredException(req, e));
-        }catch (Exception e){
+        }catch (UserNotFoundException e){
+            setExceptionRes(HttpStatus.BAD_REQUEST, res, exceptionAdvice.userNotFoundException(req, e));
+        } catch (Exception e){
             setExceptionRes(HttpStatus.INTERNAL_SERVER_ERROR, res, exceptionAdvice.defaultException(req, e));
         }
+
+
     }
 
     //

--- a/src/main/java/com/moment/the/controller/exception/ExceptionController.java
+++ b/src/main/java/com/moment/the/controller/exception/ExceptionController.java
@@ -52,4 +52,7 @@ public class ExceptionController {
 
     @GetMapping(value = "/invalid-token")
     public CommonResult invalidToken(){throw new InvalidTokenException();}
+
+    @GetMapping(value = "/answer-already-exists")
+    public CommonResult answerAlreadyExists(){throw new AnswerAlreadyExistsException();}
 }

--- a/src/main/java/com/moment/the/controller/release/TableController.java
+++ b/src/main/java/com/moment/the/controller/release/TableController.java
@@ -5,6 +5,7 @@ import com.moment.the.domain.response.CommonResult;
 import com.moment.the.domain.response.ListResult;
 import com.moment.the.domain.response.ResponseService;
 import com.moment.the.dto.TableDto;
+import com.moment.the.dto.TableViewDto;
 import com.moment.the.service.TableService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
@@ -34,7 +35,7 @@ public class TableController {
 
     // localhost:8080/v1/uncomfortable
     @GetMapping("/uncomfortable")
-    public ListResult<TableDomain> viewAll(){
+    public ListResult<TableViewDto> viewAll(){
         return responseService.getListResult(tableService.viewAll());
     }
 

--- a/src/main/java/com/moment/the/domain/AnswerDomain.java
+++ b/src/main/java/com/moment/the/domain/AnswerDomain.java
@@ -9,6 +9,8 @@ import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.*;
+
 @Table(name = "Answer")
 @Entity
 @Getter
@@ -25,16 +27,21 @@ public class AnswerDomain {
     @NotNull
     private String answerContent;
 
-    @OneToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "ReferencePost")
+    @OneToOne(mappedBy = "answerDomain", fetch = LAZY)
+    @JoinColumn(name = "boardIdx")
     private TableDomain tableDomain;
 
-    @ManyToOne(fetch = FetchType.LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name="writer")
     private AdminDomain adminDomain;
 
     // dirty checking.
     public void update(AnswerDto answerDto) {
         this.answerContent = answerDto.getContent();
+    }
+
+    public void updateTableDomain(TableDomain tableDomain){
+        this.tableDomain = tableDomain;
+        this.tableDomain.updateAnswerDomain(this);
     }
 }

--- a/src/main/java/com/moment/the/domain/TableDomain.java
+++ b/src/main/java/com/moment/the/domain/TableDomain.java
@@ -20,6 +20,10 @@ public class TableDomain {
     @Column
     private int goods;
 
+    @OneToOne(mappedBy = "tableDomain")
+    private AnswerDomain answerDomain;
+
+
     public void setGoods(int goods){
         this.goods = goods;
     }

--- a/src/main/java/com/moment/the/domain/TableDomain.java
+++ b/src/main/java/com/moment/the/domain/TableDomain.java
@@ -4,6 +4,8 @@ import lombok.*;
 
 import javax.persistence.*;
 
+import static javax.persistence.FetchType.*;
+
 @Table(name = "Board")
 @Entity
 @Getter
@@ -12,7 +14,6 @@ import javax.persistence.*;
 @Builder
 public class TableDomain {
     @Id
-    @Column
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long boardIdx;
     @Column
@@ -20,11 +21,14 @@ public class TableDomain {
     @Column
     private int goods;
 
-    @OneToOne(mappedBy = "tableDomain")
+    @OneToOne(fetch = LAZY)
     private AnswerDomain answerDomain;
 
-
-    public void setGoods(int goods){
+    public void updateGoods(int goods){
         this.goods = goods;
+    }
+
+    public void updateAnswerDomain(AnswerDomain answerDomain){
+        this.answerDomain = answerDomain;
     }
 }

--- a/src/main/java/com/moment/the/dto/AnswerDto.java
+++ b/src/main/java/com/moment/the/dto/AnswerDto.java
@@ -14,13 +14,10 @@ public class AnswerDto {
 
     @JsonIgnore
     private AdminDomain adminDomain;
-    @JsonIgnore
-    private TableDomain tableDomain;
 
     public AnswerDomain toEntity(){
         return AnswerDomain.builder()
                 .answerContent(this.content)
-                .tableDomain(this.tableDomain)
                 .adminDomain(this.adminDomain)
                 .build();
     }

--- a/src/main/java/com/moment/the/dto/AnswerDto.java
+++ b/src/main/java/com/moment/the/dto/AnswerDto.java
@@ -1,23 +1,27 @@
 package com.moment.the.dto;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.moment.the.domain.AdminDomain;
 import com.moment.the.domain.AnswerDomain;
 import com.moment.the.domain.TableDomain;
 import lombok.*;
 
-@Getter
-@Setter
 @Builder
-@NoArgsConstructor
-@AllArgsConstructor
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
 public class AnswerDto {
     private String content;
 
-    public AnswerDomain toEntity(String content, AdminDomain adminDomain, TableDomain table){
+    @JsonIgnore
+    private AdminDomain adminDomain;
+    @JsonIgnore
+    private TableDomain tableDomain;
+
+    public AnswerDomain toEntity(){
         return AnswerDomain.builder()
-                .answerContent(content)
-                .tableDomain(table)
-                .adminDomain(adminDomain)
+                .answerContent(this.content)
+                .tableDomain(this.tableDomain)
+                .adminDomain(this.adminDomain)
                 .build();
     }
 }

--- a/src/main/java/com/moment/the/dto/AnswerResDto.java
+++ b/src/main/java/com/moment/the/dto/AnswerResDto.java
@@ -1,0 +1,13 @@
+package com.moment.the.dto;
+
+import lombok.*;
+
+@Builder
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+public class AnswerResDto {
+
+    private Long answerIdx;
+    private String answerContents;
+    private String adminName;
+}

--- a/src/main/java/com/moment/the/dto/TableViewDto.java
+++ b/src/main/java/com/moment/the/dto/TableViewDto.java
@@ -1,0 +1,32 @@
+package com.moment.the.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.*;
+
+@Builder
+@Getter @Setter
+@NoArgsConstructor @AllArgsConstructor
+public class TableViewDto {
+
+    private Long boardIdx;
+    private String content;
+    private int goods;
+
+    @JsonProperty("answer")
+    private AnswerResDto answerResDto;
+
+
+    public TableViewDto(Long boardIdx, String content, int goods, Long answerIdx, String answerContents, String adminName){
+        this.boardIdx = boardIdx;
+        this.content = content;
+        this.goods = goods;
+        if(answerIdx != null){
+            this.answerResDto =
+                    AnswerResDto.builder()
+                            .answerIdx(answerIdx)
+                            .answerContents(answerContents)
+                            .adminName(adminName)
+                            .build();
+        }
+    }
+}

--- a/src/main/java/com/moment/the/repository/TableRepository.java
+++ b/src/main/java/com/moment/the/repository/TableRepository.java
@@ -2,7 +2,9 @@ package com.moment.the.repository;
 
 import com.moment.the.domain.TableDomain;
 import com.moment.the.dto.TableDto;
+import com.moment.the.dto.TableViewDto;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -17,4 +19,10 @@ public interface TableRepository extends JpaRepository<TableDomain, Long>{
     List<TableDomain> findTop10ByOrderByGoodsDesc();
 
     List<TableDomain> findAllByOrderByBoardIdxDesc();
+
+    @Query("SELECT new com.moment.the.dto.TableViewDto(table.boardIdx, table.content, table.goods, answer.answerIdx, answer.answerContent, admin.adminName)" +
+            "FROM TableDomain table LEFT JOIN table.answerDomain answer LEFT JOIN answer.adminDomain admin " +
+            "ORDER BY table.boardIdx DESC "
+    )
+    List<TableViewDto> tableViewAll();
 }

--- a/src/main/java/com/moment/the/service/TableService.java
+++ b/src/main/java/com/moment/the/service/TableService.java
@@ -4,9 +4,9 @@ import com.moment.the.advice.exception.GoodsNotCancelException;
 import com.moment.the.advice.exception.NoPostException;
 import com.moment.the.domain.TableDomain;
 import com.moment.the.dto.TableDto;
+import com.moment.the.dto.TableViewDto;
 import com.moment.the.repository.TableRepository;
 import lombok.RequiredArgsConstructor;
-import org.modelmapper.ModelMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -29,15 +29,15 @@ public class TableService {
     }
 
     // 전체 페이지 보여주기.
-    public List<TableDomain> viewAll(){
-        return tableRepository.findAllByOrderByBoardIdxDesc();
+    public List<TableViewDto> viewAll(){
+        return tableRepository.tableViewAll();
     }
 
     // 좋아요 수 증가.
     @Transactional
     public void goods(Long boardIdx){
         TableDomain tableDomain = tableRepository.findByBoardIdx(boardIdx).orElseThrow(NoPostException::new);
-        tableDomain.setGoods(tableDomain.getGoods()+1);
+        tableDomain.updateGoods(tableDomain.getGoods()+1);
     }
 
     // 좋아요 수 감소.
@@ -48,6 +48,6 @@ public class TableService {
         if(tableDomain.getGoods() - 1 <= 0) //좋야요가 음수가 되면
             throw new GoodsNotCancelException();
 
-        tableDomain.setGoods(tableDomain.getGoods() - 1);
+        tableDomain.updateGoods(tableDomain.getGoods() - 1);
     }
 }

--- a/src/main/resources/i18n/exception_en.yml
+++ b/src/main/resources/i18n/exception_en.yml
@@ -18,6 +18,10 @@ noComment:
   code: "-777"
   msg: "I can't find that answer."
 
+answer-already-exists:
+  code: "-776"
+  msg: "Corresponding 'Inconvenient Moment' already have an answer."
+
 noImprovement:
   code: "-666"
   msg: "No such improvement can be found."

--- a/src/main/resources/i18n/exception_ko.yml
+++ b/src/main/resources/i18n/exception_ko.yml
@@ -18,6 +18,10 @@ noComment:
   code: "-777"
   msg: "해당 답변을 찾을 수 없습니다."
 
+answer-already-exists:
+  code: "-776"
+  msg: "해당 '불편한 순간' 에 대한 답변이 이미 있습니다."
+
 noImprovement:
   code: "-666"
   msg: "해당 개선 사례를 찾을 수 없습니다."


### PR DESCRIPTION
answer save 로직에 대해 모든 작업이 완료되었습니다. 
TableDomain과 AnswerDomain의 연관관계를 재설정 하였고 연관관계 편의 매서드를 생성했습니다.

---

TableDomain과 AnswerDomain의 연관관계를 재설정하는 과정에서 
TableController에 있는 [GET] /v1/uncomfortable viewAll (불편한 순간 모두 조회 API)에서 순환 참조요류 및 회원정보가 모두 유출되는 에러가 발생했습니다.  
 
그리하여 TableService의 viewAll 로직은 TableRepository에 있는 findAllByOrderByBoardIdxDesc 매서드를 사용하는대신  tableViewAll매서드를 사용합니다.

```java
    //기존 사용하던 view all
    List<TableDomain> findAllByOrderByBoardIdxDesc();
 
    //현제 사용중인 view all
    @Query("SELECT new com.moment.the.dto.TableViewDto(table.boardIdx, table.content, table.goods, answer.answerIdx, answer.answerContent, admin.adminName)" +
            "FROM TableDomain table LEFT JOIN table.answerDomain answer LEFT JOIN answer.adminDomain admin " +
            "ORDER BY table.boardIdx DESC "
    )
    List<TableViewDto> tableViewAll();
```