### PR TITLE
Hotfix

### DIFF
--- a/docker-compose-evn.sh
+++ b/docker-compose-evn.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+echo "====mvn clean======"
+mvn clean
+
+echo "=====mvn compile====="
+mvn compile
+
+echo "======mvn package======"
+mvn package
+
+echo "======docker-compose build======"
+docker-compose build
+
+echo "======docker-compose up======="
+docker-compose up

--- a/src/main/java/com/moment/the/service/AnswerService.java
+++ b/src/main/java/com/moment/the/service/AnswerService.java
@@ -115,7 +115,7 @@ public class AnswerService {
 
     public void answerOwnerCheck(AdminDomain answerAdmin, AdminDomain loginAdmin){
         boolean isAdminOwnerThisAnswer = answerAdmin == loginAdmin;
-        if(isAdminOwnerThisAnswer)
+        if(!isAdminOwnerThisAnswer)
             throw new AccessNotFoundException();
     }
 }


### PR DESCRIPTION
아래와 같은 문제를 해결 했습니다.
1. answerDomain의 delete function 문제해결.
```java
// before
boolean isAdminOwnerThisAnswer = answerAdmin == loginAdmin;
        if(isAdminOwnerThisAnswer)
            throw new AccessNotFoundException();

//after
boolean isAdminOwnerThisAnswer = answerAdmin == loginAdmin;
        if(!isAdminOwnerThisAnswer)
            throw new AccessNotFoundException();
```
2. docker-compose build 시 기존 redis container port와 conflict 문제해결.
-> ``docker-compose-env.sh`` 추가

아래와 같이 실행하면 됩니다.
```sh
$ chmod 700 ./docker-compose-env.sh
$ ./docker-compose-env.sh
```
